### PR TITLE
fix: remove links reference from wiki page

### DIFF
--- a/wiki/public/js/wiki.min.js
+++ b/wiki/public/js/wiki.min.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+
+
+}());
+//# sourceMappingURL=wiki.min.js.map

--- a/wiki/public/js/wiki.min.js.map
+++ b/wiki/public/js/wiki.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"wiki.min.js","sources":[],"sourcesContent":[],"names":[],"mappings":";;;;;"}

--- a/wiki/wiki/doctype/wiki_page/wiki_page.json
+++ b/wiki/wiki/doctype/wiki_page/wiki_page.json
@@ -74,18 +74,7 @@
  "has_web_view": 1,
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
- "links": [
-  {
-   "group": "Linked Documents",
-   "link_doctype": "Wiki Page Revision",
-   "link_fieldname": "wiki_page"
-  },
-  {
-   "group": "Linked Documents",
-   "link_doctype": "Wiki Page Patch",
-   "link_fieldname": "wiki_page"
-  }
- ],
+ "links": [],
  "modified": "2021-09-14 14:39:13.174629",
  "modified_by": "Administrator",
  "module": "Wiki",


### PR DESCRIPTION
Remove links reference as of there is no links field in wiki page doctype